### PR TITLE
update CoC link

### DIFF
--- a/files/en-us/mdn/community/roles_teams/index.md
+++ b/files/en-us/mdn/community/roles_teams/index.md
@@ -47,7 +47,7 @@ As a contributor, you can get involved with the project by engaging in the follo
 
 To be a contributor, you must follow:
 
-- [Mozilla's code of conduct](https://github.com/mdn/mdn-community/blob/main/CODE_OF_CONDUCT.md)
+- [Mozilla's code of conduct](https://www.mozilla.org/en-US/about/governance/policies/participation/)
 - Contribution guidelines (check the `CONTRIBUTING.md` file in each repository; for example, these are the [contribution guidelines](https://github.com/mdn/content/blob/main/CONTRIBUTING.md) for the `mdn/content` repository).
 
 **Privileges:**


### PR DESCRIPTION
The current link links to a blob on github that links to the CoC. This changes the link to go to the CoC directly. The text does read "Mozilla's" ( not "MDN's")  "code of conduct", so pointing directly to that makes sense, and removes a click

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
